### PR TITLE
on mobile, keep tel links active. disable on non-mobile

### DIFF
--- a/src/_scripts/elements/_tel-links.js
+++ b/src/_scripts/elements/_tel-links.js
@@ -1,0 +1,50 @@
+'use strict';
+
+import $ from 'jquery';
+
+import {prefix} from '../utilities/_helpers';
+
+// if not a mobile device, disable tel links
+(function($) {
+    var $telLinks = $('a[href^="tel:"]');
+    // if not mobile
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent (see summary at bottom of page)
+    if (!/Mobi/.test(navigator.userAgent)) {
+        // http://stackoverflow.com/questions/754607/can-jquery-get-all-css-styles-associated-with-an-element#answer-6416527
+        $.fn.getStyleObject = function(){
+            var dom = this.get(0);
+            var style;
+            var returns = {};
+            if(window.getComputedStyle){
+                var camelize = function(a,b){
+                    return b.toUpperCase();
+                };
+                style = window.getComputedStyle(dom, null);
+                for(var i = 0, l = style.length; i < l; i++){
+                    var prop = style[i];
+                    var camel = prop.replace(/\-([a-z])/g, camelize);
+                    var val = style.getPropertyValue(prop);
+                    returns[camel] = val;
+                };
+                return returns;
+            };
+            if(style = dom.currentStyle){
+                for(var prop in style){
+                    returns[prop] = style[prop];
+                };
+                return returns;
+            };
+            return this.css();
+        }
+        $telLinks.each(function(index, link) {
+            var $link = $(link),
+                prefixedClass = prefix('tel-link'),
+                $newElement = $(`<span class="${prefixedClass}"></span>`),
+                linkText = $link.text(),
+                elementCSS = $link.getStyleObject();
+            $newElement.css(elementCSS);
+            $newElement.text(linkText);
+            $link.replaceWith($newElement);
+        });
+    }
+})(jQuery);

--- a/src/_scripts/main.custom.js
+++ b/src/_scripts/main.custom.js
@@ -4,6 +4,7 @@
 import './elements/_equalize';
 import './elements/_placeholder-label';
 import './elements/_prevent';
+import './elements/_tel-links';
 
 // Groups
 

--- a/src/_styles/elements/anchor.scss
+++ b/src/_styles/elements/anchor.scss
@@ -3,14 +3,14 @@
 // http://stackoverflow.com/questions/39543197/get-the-documents-background-color/39543711#39543711
 // https://www.w3.org/TR/2010/PR-css3-color-20101028/#css2-system
 .fs-tel-link::-moz-selection {
-    color: white;
+    color: $color-white;
     background-color: #4497e8;
     // https://www.w3.org/TR/2010/PR-css3-color-20101028/#css2-system
     // no longer part of spec, but works in most browsers
     background-color: Highlight;
 }
 .fs-tel-link::selection {
-    color: white;
+    color: $color-white;
     background-color: #4497e8;
     background-color: Highlight;
 }

--- a/src/_styles/elements/anchor.scss
+++ b/src/_styles/elements/anchor.scss
@@ -1,0 +1,17 @@
+// style (fake) tel links
+// see tel-links.js
+// http://stackoverflow.com/questions/39543197/get-the-documents-background-color/39543711#39543711
+// https://www.w3.org/TR/2010/PR-css3-color-20101028/#css2-system
+.fs-tel-link::-moz-selection {
+    color: white;
+    background-color: #4497e8;
+    // https://www.w3.org/TR/2010/PR-css3-color-20101028/#css2-system
+    // no longer part of spec, but works in most browsers
+    background-color: Highlight;
+}
+.fs-tel-link::selection {
+    color: white;
+    background-color: #4497e8;
+    background-color: Highlight;
+}
+// end style (fake) tel links

--- a/src/_styles/main.custom.scss
+++ b/src/_styles/main.custom.scss
@@ -17,6 +17,7 @@
 @import './elements/switch';
 @import './elements/typography';
 @import './elements/video';
+@import './elements/anchor';
 
 // Groups
 @import './groups/dropdown';

--- a/src/_templates/modules/footer.pug
+++ b/src/_templates/modules/footer.pug
@@ -3,7 +3,7 @@
         .container
             .row
                 .col-xs-12
-                    a.text-center(href='tel:2063691919') 206-369-1919
+                    a.text-center(href='tel:1-206-369-1919') 206-369-1919
             .row
                 .col-xs-12
                     ul.list-inline

--- a/src/_templates/modules/footer.pug
+++ b/src/_templates/modules/footer.pug
@@ -3,6 +3,9 @@
         .container
             .row
                 .col-xs-12
+                    a.text-center(href='tel:2063691919') 206-369-1919
+            .row
+                .col-xs-12
                     ul.list-inline
                         li.list-inline-item
                             a(href="javascript:void(0)")


### PR DESCRIPTION
This was a request from Mark for the FS site. After reviewing the UX, I agree with him, that having tel links on desktop is a sub-par experience.

That being said, I'd like to discuss this solution, as It seems like there should be a _radically_ easier way to do this. There probably is, maybe my googlefu was lacking yesterday.

I started out applying pointer-events: none to the link, which works some of the time. However, there are weird browser inconsistencies, such as in Edge & IE, when you highlight the text it doesn't look like other highlighted text. I tried a ton of things, but browsers are aggressive with how they handle anchor tags & text that looks like a tel number.

Wasn't able to come up with a cross-browser solution that kept the anchor tag an anchor tag, allowed the number text to be selected, and did not trigger some browser auto-highlighting or other weirdness, does not require special markup (my first approach was to put a tel link and a span with the tel number in it and show/hide them based mobile detection. it's ok but fragile, as it's almost for sure site authors will forget to use the special markup as links are added)

So, this solution replaces the anchor tag with a span that has all the css from the tel link applied. Probably not performant, so a page with a bunch of tel links might suffer. But it does the thing and is cross-browser/device tested.