### PR TITLE
Fix build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "slick-carousel": "^1.6.0",
     "svg4everybody": "^2.1.2",
     "tether": "^1.3.7",
-    "velocity-animate": "^1.3.1"
+    "velocity-animate": "^1.3.1",
+    "xmlfmt": "^1.0.0"
   },
   "devDependencies": {
     "autoprefixer": "~6.5.3",

--- a/src/_styles/_mix.scss
+++ b/src/_styles/_mix.scss
@@ -18,12 +18,12 @@
     $x0: 1;
     $x1: $x0;
     $r: strip-unit($r);
- 
+
     @for $i from 1 through 10 {
         $x1: $x0 - ($x0 * $x0 - abs($r)) / (2 * $x0);
         $x0: $x1;
     }
- 
+
     @return $x1;
 }
 
@@ -36,7 +36,7 @@
     border-image-slice: 1;
 }
 
-@mixin font-size($size, $lead: ($size + 4) / $size, $root: $font-size-root) {
+@mixin font-size($size, $lead: ($size + 4) / $size, $root: $font-size-base) {
     font-size: $size;
     font-size: ($size / $root) + rem;
     line-height: $lead;


### PR DESCRIPTION
1. Update font-size mixin to use Bootstrap's $font-size-base variable rather than undefined $font-size-root variable

2. Add missing xmlfmt package to package.json